### PR TITLE
Custom Headers in gql-ts

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,3 +1,5 @@
 {
-    "deno.enable": true
+    "deno.enable": true,
+    "deno.lint": true,
+    "deno.unstable": true
 }

--- a/gql-ts/cli.ts
+++ b/gql-ts/cli.ts
@@ -18,8 +18,8 @@ let fileOut = "./schema.ts";
 let addNull = false;
 let addIPrefix = true;
 let buildClasses = false;
-let namespace = "";
 let endpoint = "";
+const namespace = "";
 
 /**
  * -f   file path to schema.json
@@ -55,7 +55,7 @@ Deno.args.forEach((arg: string) => {
         case "-s":
             try {
                 //TODO: Only working in this format: "[{\"key\":\"char\",\"value\":\"string\"}]"
-                let scalarObj = JSON.parse(Deno.args[argIdx + 1]) as { key:string, value:string }[];
+                const scalarObj = JSON.parse(Deno.args[argIdx + 1]) as { key:string, value:string }[];
 
                 if (typeof(scalarObj) === "object") {
                     scalarObj.forEach(i => {
@@ -98,22 +98,23 @@ addScalar("Int", "number");
 if (fileIn.trim() !== "" && fileOut.trim() !== "") {
     Deno.readTextFile(fileIn)
         .then((res: string) => {
-            let opt = {
+            const opt = {
                 namespace: namespace,
                 buildClasses: buildClasses,
                 addIPrefix: addIPrefix,
                 addNull: addNull
             };
-            let obj = JSON.parse(res);
-            let str = TypesBuilder(obj, opt);
+            const obj = JSON.parse(res);
+            const str = TypesBuilder(obj, opt);
             Deno.writeTextFile(fileOut, str);
         })
+        // deno-lint-ignore no-explicit-any
         .catch((err: any) => {
             console.log(err);
         });
 }
 else if (endpoint.trim() !== "" && fileOut.trim() !== "") {
-    let qry = IntrospectionQuery();
+    const qry = IntrospectionQuery();
 
     fetch(endpoint, {
         method: "POST",
@@ -124,16 +125,16 @@ else if (endpoint.trim() !== "" && fileOut.trim() !== "") {
         credentials: 'include',
         body: JSON.stringify(qry)
     }).then( async (resp) => { 
-        let txt = await resp.text();
+        const txt = await resp.text();
         try {
-            let opt = {
+            const opt = {
                 namespace: namespace,
                 buildClasses: buildClasses,
                 addIPrefix: addIPrefix,
                 addNull: addNull
             };
-            let obj = JSON.parse(txt);
-            let str = TypesBuilder(obj, opt);
+            const obj = JSON.parse(txt);
+            const str = TypesBuilder(obj, opt);
             if (fileOut.trim() !== "") {
                 Deno.writeTextFile(fileOut, str);
             }

--- a/gql-ts/introspection-query.ts
+++ b/gql-ts/introspection-query.ts
@@ -6,7 +6,7 @@ export default () => {
     }
 }
  
-let introspectionQuery = `query IntrospectionQuery {
+const introspectionQuery = `query IntrospectionQuery {
     __schema {
         queryType { name }
         mutationType { name }

--- a/gql-ts/introspection-schema.d.ts
+++ b/gql-ts/introspection-schema.d.ts
@@ -1,4 +1,5 @@
 export interface Introspection {
+    // deno-lint-ignore no-explicit-any
     errors: any[];
     data: {
         "__schema": Schema

--- a/gql-ts/mod.ts
+++ b/gql-ts/mod.ts
@@ -6,12 +6,14 @@ export class GQLTS {
     constructor() {
         this.Class = false;
         this.Endpoint = "";
+        this.Headers = {};
         this.Interface = true;
         this.Nullable = false;
         this.OutFile = "./schema.ts";
         this.SchemaFile = "";
         this.Namespace = "";
     }
+    public Headers: { [key: string]: string }
     public OutFile: string;
     public Endpoint: string;
     public SchemaFile: string;
@@ -60,7 +62,8 @@ export class GQLTS {
                 method: "POST",
                 cache: "no-cache",
                 headers: {
-                    'Content-Type': 'application/json'
+                    'Content-Type': 'application/json',
+                    ...this.Headers
                 },
                 credentials: 'include',
                 body: JSON.stringify(qry)

--- a/gql-ts/mod.ts
+++ b/gql-ts/mod.ts
@@ -20,6 +20,7 @@ export class GQLTS {
     public Nullable: boolean;
     public Namespace: string;
 
+    // deno-lint-ignore no-explicit-any
     public AddScalar(name: any, value: any): void {
         addScalar(name, value);
     }
@@ -37,22 +38,23 @@ export class GQLTS {
         if (this.SchemaFile.trim() !== "" && this.OutFile.trim() !== "") {
             Deno.readTextFile(this.SchemaFile)
                 .then((res: string) => {
-                    let opt = {
+                    const opt = {
                         namespace: this.Namespace,
                         buildClasses: this.Class,
                         addIPrefix: this.Interface,
                         addNull: this.Nullable
                     };
-                    let obj = JSON.parse(res);
-                    let str = TypesBuilder(obj, opt);
+                    const obj = JSON.parse(res);
+                    const str = TypesBuilder(obj, opt);
                     Deno.writeTextFile(this.OutFile, str);
                 })
+                // deno-lint-ignore no-explicit-any
                 .catch((err: any) => {
                     console.log(err);
                 });
         }
         else if (this.Endpoint.trim() !== "" && this.OutFile.trim() !== "") {
-            let qry = IntrospectionQuery();
+            const qry = IntrospectionQuery();
 
             fetch(this.Endpoint, {
                 method: "POST",
@@ -63,16 +65,16 @@ export class GQLTS {
                 credentials: 'include',
                 body: JSON.stringify(qry)
             }).then( async (resp) => { 
-                let txt = await resp.text();
+                const txt = await resp.text();
                 try {
-                    let opt = {
+                    const opt = {
                         namespace: this.Namespace,
                         buildClasses: this.Class,
                         addIPrefix: this.Interface,
                         addNull: this.Nullable
                     };
-                    let obj = JSON.parse(txt);
-                    let str = TypesBuilder(obj, opt);
+                    const obj = JSON.parse(txt);
+                    const str = TypesBuilder(obj, opt);
                     if (this.OutFile.trim() !== "") {
                         Deno.writeTextFile(this.OutFile, str);
                     }
@@ -84,7 +86,7 @@ export class GQLTS {
                 console.error(err);
             });
         }
-    };
+    }
 }
 
 export default GQLTS;

--- a/gql-ts/ts-builder.ts
+++ b/gql-ts/ts-builder.ts
@@ -1,6 +1,6 @@
 import { Introspection } from "./introspection-schema.d.ts";
 
-let typeMapping = [] as { key: string, value: string }[];
+const typeMapping = [] as { key: string, value: string }[];
 
 /** Checks Scalar type and returns Typescript type 
  * @param name name to search on
@@ -32,7 +32,7 @@ export function addScalar(key: string, value: string) {
  */
 export function TypesBuilder(introspection: Introspection, opt: { namespace: string, buildClasses: boolean, addIPrefix: boolean, addNull: boolean }): string {
     let sb = "";            // main string builder
-    let tab = "    ";       // set the indented spaces
+    const tab = "    ";       // set the indented spaces
     let queryClass = "";    // string builder for the query classes
     let sbClass = "";       // string builder for the class object
     let argumentClass = ""  // string builder for the argument class;
@@ -59,7 +59,7 @@ export function TypesBuilder(introspection: Introspection, opt: { namespace: str
                     }
                     else {
                         //process args
-                        let args = new Array<string>();
+                        const args = new Array<string>();
                         f.args.forEach(a => {
                             //console.log(a.type);
                             if (a.type.kind === "SCALAR") {


### PR DESCRIPTION
Add support for adding custom headers to the introspection query, which can be used to introspect APIs that require authentication.

Also adds support for an easier syntax when defining custom scalars.